### PR TITLE
Add indices to replay buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ qualitatively inspecting continual learning behavior.
   performs the same comparison with **PCA**, and `plot_z_bank_umap` relies on
   **UMAP** if available. Each helper saves a scatter plot contrasting original
   and replayed vectors.
+- Each entry stored in ``z_bank`` now includes an ``"idx"`` field holding the
+  starting index of the window it came from. This allows replayed samples to be
+  aligned with the original time series for precise comparisons.
 - `visualize_cpd_detection(series, penalty=None, min_size=30, save_path="cpd_detection.png")`
   draws change points detected by `ruptures`. When `penalty` is ``None`` a
   heuristic based on series length is used, and `min_size` enforces a minimum

--- a/data_factory/data_loader.py
+++ b/data_factory/data_loader.py
@@ -14,11 +14,12 @@ import pickle
 
 
 class PSMSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0, return_index: bool = False):
         self.mode = mode
         self.step = step
         self.win_size = win_size
         self.scaler = StandardScaler()
+        self.return_index = return_index
         data = pd.read_csv(data_path + '/train.csv')
         data = data.values[:, 1:]
 
@@ -57,26 +58,32 @@ class PSMSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        start = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            window = self.train[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'val':
+            window = self.val[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'test':
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            start = index // self.step * self.win_size
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
+        if self.return_index:
+            return np.float32(window), np.float32(label), start
+        return np.float32(window), np.float32(label)
 
 
 class MSLSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0, return_index: bool = False):
         self.mode = mode
         self.step = step
         self.win_size = win_size
         self.scaler = StandardScaler()
+        self.return_index = return_index
         data = np.load(data_path + "/MSL_train.npy")
         self.scaler.fit(data)
         data = self.scaler.transform(data)
@@ -102,26 +109,32 @@ class MSLSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        start = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            window = self.train[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'val':
+            window = self.val[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'test':
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            start = index // self.step * self.win_size
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
+        if self.return_index:
+            return np.float32(window), np.float32(label), start
+        return np.float32(window), np.float32(label)
 
 
 class SMAPSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0, return_index: bool = False):
         self.mode = mode
         self.step = step
         self.win_size = win_size
         self.scaler = StandardScaler()
+        self.return_index = return_index
         data = np.load(data_path + "/SMAP_train.npy")
         self.scaler.fit(data)
         data = self.scaler.transform(data)
@@ -147,26 +160,32 @@ class SMAPSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        start = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            window = self.train[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'val':
+            window = self.val[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'test':
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            start = index // self.step * self.win_size
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
+        if self.return_index:
+            return np.float32(window), np.float32(label), start
+        return np.float32(window), np.float32(label)
 
 
 class SMDSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0, return_index: bool = False):
         self.mode = mode
         self.step = step
         self.win_size = win_size
         self.scaler = StandardScaler()
+        self.return_index = return_index
         data = np.load(data_path + "/SMD_train.npy")
         self.scaler.fit(data)
         data = self.scaler.transform(data)
@@ -191,29 +210,34 @@ class SMDSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        start = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
-        elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            window = self.train[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'val':
+            window = self.val[start:start + self.win_size]
+            label = self.test_labels[0:self.win_size]
+        elif self.mode == 'test':
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            start = index // self.step * self.win_size
+            window = self.test[start:start + self.win_size]
+            label = self.test_labels[start:start + self.win_size]
+        if self.return_index:
+            return np.float32(window), np.float32(label), start
+        return np.float32(window), np.float32(label)
 
 
-def get_loader_segment(data_path, batch_size, win_size=100, step=100, mode='train', dataset='KDD', train_start=0.0, train_end=1.0):
+def get_loader_segment(data_path, batch_size, win_size=100, step=100, mode='train', dataset='KDD', train_start=0.0, train_end=1.0, return_index: bool = False):
     if (dataset == 'SMD'):
-        dataset = SMDSegLoader(data_path, win_size, step, mode, train_start, train_end)
+        dataset = SMDSegLoader(data_path, win_size, step, mode, train_start, train_end, return_index=return_index)
     elif (dataset == 'MSL'):
-        dataset = MSLSegLoader(data_path, win_size, 1, mode, train_start, train_end)
+        dataset = MSLSegLoader(data_path, win_size, 1, mode, train_start, train_end, return_index=return_index)
     elif (dataset == 'SMAP'):
-        dataset = SMAPSegLoader(data_path, win_size, 1, mode, train_start, train_end)
+        dataset = SMAPSegLoader(data_path, win_size, 1, mode, train_start, train_end, return_index=return_index)
     elif (dataset == 'PSM'):
-        dataset = PSMSegLoader(data_path, win_size, 1, mode, train_start, train_end)
+        dataset = PSMSegLoader(data_path, win_size, 1, mode, train_start, train_end, return_index=return_index)
 
     shuffle = False
     if mode == 'train':

--- a/solver.py
+++ b/solver.py
@@ -97,11 +97,16 @@ class Solver(object):
 
         self.update_count = 0
 
-        self.train_loader = get_loader_segment(self.data_path, batch_size=self.batch_size, win_size=self.win_size,
-                                               mode='train',
-                                               dataset=self.dataset,
-                                               train_start=self.train_start,
-                                               train_end=self.train_end)
+        self.train_loader = get_loader_segment(
+            self.data_path,
+            batch_size=self.batch_size,
+            win_size=self.win_size,
+            mode='train',
+            dataset=self.dataset,
+            train_start=self.train_start,
+            train_end=self.train_end,
+            return_index=True,
+        )
         self.vali_loader = get_loader_segment(self.data_path, batch_size=self.batch_size, win_size=self.win_size,
                                               mode='val',
                                               dataset=self.dataset,
@@ -194,7 +199,11 @@ class Solver(object):
 
         # energies on train set
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.train_loader):
+        for i, batch in enumerate(self.train_loader):
+            if len(batch) == 3:
+                input_data, labels, _ = batch
+            else:
+                input_data, labels = batch
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
             loss = torch.mean(criterion(input, output), dim=-1)
@@ -226,7 +235,11 @@ class Solver(object):
         # energies on threshold loader
         attens_energy = []
         test_labels = []
-        for i, (input_data, labels) in enumerate(self.thre_loader):
+        for i, batch in enumerate(self.thre_loader):
+            if len(batch) == 3:
+                input_data, labels, _ = batch
+            else:
+                input_data, labels = batch
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
             loss = torch.mean(criterion(input, output), dim=-1)
@@ -317,7 +330,12 @@ class Solver(object):
 
             epoch_time = time.time()
             self.model.train()
-            for i, (input_data, labels) in enumerate(self.train_loader):
+            for i, batch in enumerate(self.train_loader):
+                if len(batch) == 3:
+                    input_data, labels, indices = batch
+                else:
+                    input_data, labels = batch
+                    indices = None
 
                 iter_count += 1
                 input = input_data.float().to(self.device)
@@ -327,6 +345,7 @@ class Solver(object):
                         self.model,
                         self.optimizer,
                         input,
+                        indices=indices,
                         cpd_penalty=getattr(self, 'cpd_penalty', 20),
                         min_gap=getattr(self, 'min_cpd_gap', 30),
                     )
@@ -483,7 +502,11 @@ class Solver(object):
 
         # (1) stastic on the train set
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.train_loader):
+        for i, batch in enumerate(self.train_loader):
+            if len(batch) == 3:
+                input_data, labels, _ = batch
+            else:
+                input_data, labels = batch
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
             loss = torch.mean(criterion(input, output), dim=-1)
@@ -517,7 +540,11 @@ class Solver(object):
 
         # (2) find the threshold
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.thre_loader):
+        for i, batch in enumerate(self.thre_loader):
+            if len(batch) == 3:
+                input_data, labels, _ = batch
+            else:
+                input_data, labels = batch
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
 
@@ -557,7 +584,11 @@ class Solver(object):
         # (3) evaluation on the test set
         test_labels = []
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.thre_loader):
+        for i, batch in enumerate(self.thre_loader):
+            if len(batch) == 3:
+                input_data, labels, _ = batch
+            else:
+                input_data, labels = batch
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
 

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -89,6 +89,22 @@ def test_z_bank_stores_x():
     assert torch.equal(model.z_bank[0]["x"], dummy[0])
 
 
+def test_z_bank_stores_idx():
+    model = AnomalyTransformerAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+    )
+    dummy = torch.ones(2, 4, 1)
+    idxs = torch.tensor([5, 6])
+    model(dummy, indices=idxs)
+    assert model.z_bank[0]["idx"] == 5 and model.z_bank[1]["idx"] == 6
+
+
 def test_replay_consistency_loss():
     model = AnomalyTransformerAE(
         win_size=4,
@@ -107,6 +123,7 @@ def test_replay_consistency_loss():
         model,
         opt,
         dummy,
+        indices=torch.tensor([0]),
         replay_consistency_weight=1.0,
         cpd_penalty=0,
     )

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -117,7 +117,7 @@ def _collect_latents(model, loader, n_samples):
 
     if not model.z_bank:
         raise ValueError("z_bank is empty; train the model before calling")
-    replay_latents = torch.stack([entry[1] for entry in model.z_bank]).cpu().numpy()
+    replay_latents = torch.stack([entry["z"] for entry in model.z_bank]).cpu().numpy()
     replay_latents = replay_latents[-n_samples:]
 
     return orig_latents, replay_latents


### PR DESCRIPTION
## Summary
- extend dataset loaders to optionally return starting indices
- record these indices in `z_bank` entries
- ensure dataloaders pass index info to the model for alignment
- note the new `idx` field in the README
- update tests accordingly

## Testing
- `pip install -r requirements-demo.txt` *(fails: Tunnel connection failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874df545bfc8323b9e99608896926d8