### PR TITLE
Handle single-class metrics

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -304,8 +304,15 @@ class Solver(object):
         gt = np.array(gt)
 
         precision, recall, f_score, _ = precision_recall_fscore_support(
-            gt, pred, average='binary')
-        auc = roc_auc_score(gt, attens_energy)
+            gt, pred, average='binary', zero_division=0)
+
+        if len(np.unique(gt)) < 2:
+            warnings.warn(
+                "Only one class present in y_true. ROC AUC is undefined.")
+            auc = float("nan")
+        else:
+            auc = roc_auc_score(gt, attens_energy)
+
         return f_score, auc
 
     def train(self):


### PR DESCRIPTION
## Summary
- fix solver metric computation when only one class is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752b47e6508323bb84d90ebfbed9bf