### PR TITLE
Enable aligned CPD replay visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--cpd_log_interval`: evaluate and print metrics only after this many CPD
   updates (default `20`).
 - `--replay_plot`: optional path for saving a figure comparing replayed samples
-  with the training data. A success message with the absolute location is
-  printed after saving.
+  with the training data. When supplied, the visualization aligns windows using the stored `"idx"` values and focuses on the most recent CPD update. A success message with the absolute location is printed after saving.
 - `--cpd_top_k`: number of zoomed views for CPD visualization (default `3`).
 - `--cpd_extra_ranges`: comma-separated `start:end` pairs for fixed CPD zoom
   windows (default `0:4000`).

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -41,13 +41,17 @@ def train_and_test(args: argparse.Namespace) -> None:
 
             series = series[:, 0]
             out_path = os.path.abspath(args.replay_plot)
+            start_idx = 0
+            if getattr(solver, "cpd_indices", None):
+                start_idx = solver.cpd_indices[-1]
             plot_replay_vs_series(
                 solver.model,
                 series,
-                start=0,
-                end=len(series),
+                start=start_idx,
+                end=min(len(series), start_idx + 4000),
                 save_path=out_path,
                 ordered=True,
+                use_indices=True,
             )
             if os.path.isfile(out_path):
                 print(f"Replay comparison saved to {out_path}")

--- a/solver.py
+++ b/solver.py
@@ -96,6 +96,7 @@ class Solver(object):
         self.train_end = getattr(self, 'train_end', 1.0)
 
         self.update_count = 0
+        self.cpd_indices: list[int] = []
 
         self.train_loader = get_loader_segment(
             self.data_path,
@@ -359,6 +360,8 @@ class Solver(object):
                     loss1_list.append(loss)
                     if updated:
                         self.update_count += 1
+                        if indices is not None and len(indices) > 0:
+                            self.cpd_indices.append(int(indices[0]))
                         if self.update_count % getattr(self, 'cpd_log_interval', 20) == 0:
                             # evaluate periodically after concept drift update
                             vali_loss1, vali_loss2 = self.vali(self.test_loader)

--- a/tests/test_replay_plot.py
+++ b/tests/test_replay_plot.py
@@ -22,13 +22,25 @@ def test_plot_replay_vs_series(tmp_path):
     tensor_series = torch.tensor(series, dtype=torch.float32).unsqueeze(-1)
     windows = [tensor_series[i : i + model.win_size] for i in range(len(series) - model.win_size + 1)]
     data = torch.stack(windows)
+    indices = torch.arange(len(data))
     loader = torch.utils.data.DataLoader(
-        torch.utils.data.TensorDataset(data, torch.zeros(len(data))), batch_size=1
+        torch.utils.data.TensorDataset(data, torch.zeros(len(data)), indices), batch_size=1
     )
     with torch.no_grad():
-        for batch, _ in loader:
-            model(batch)
+        for batch in loader:
+            model(batch[0], indices=batch[2])
     out = tmp_path / "replay.png"
     plot_replay_vs_series(model, series, end=20, save_path=str(out), ordered=True)
     assert out.exists() and out.stat().st_size > 0
+
+    out2 = tmp_path / "replay_idx.png"
+    plot_replay_vs_series(
+        model,
+        series,
+        end=20,
+        save_path=str(out2),
+        ordered=True,
+        use_indices=True,
+    )
+    assert out2.exists() and out2.stat().st_size > 0
 


### PR DESCRIPTION
## Summary
- track update indices during continual training
- allow `plot_replay_vs_series` to align using stored indices
- plot the last CPD replay automatically when `--replay_plot` is given
- document new behaviour
- extend replay plot test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753cf1e2b883238930b12397e8098b