### PR TITLE
Fix SKAB dataset feature mismatch by excluding changepoint column

### DIFF
--- a/data_factory/data_loader.py
+++ b/data_factory/data_loader.py
@@ -252,6 +252,11 @@ def _skab_autodetect_cols(df: pd.DataFrame):
 
     feats = [c for c in df.columns if c not in {ts_col, label_col}]
     feats = [c for c in feats if np.issubdtype(df[c].dtype, np.number)]
+    # 일부 파일에는 anomaly 이외에도 changepoint 등의 추가 레이블 열이 존재한다.
+    # 이런 열이 특징으로 포함되면 파일 간 특성 차원수가 달라져 스택 시 오류가 발생한다.
+    # 따라서 명시적으로 레이블 관련 열을 제외하여 모든 파일에서 동일한
+    # 특성 차원을 유지하도록 한다.
+    feats = [c for c in feats if c.lower() not in {"anomaly", "changepoint"}]
     return ts_col, label_col, feats
 
 


### PR DESCRIPTION
## Summary
- Exclude auxiliary label columns like `changepoint` from SKAB feature list to keep window shapes consistent

## Testing
- `pytest -q`
- `python incremental_experiment.py --dataset SKAB --data_path data --model_type transformer_ae --win_size 128 --stride 16 --batch_size 256 --num_epochs 1 --lr 1e-3` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a6de8c9efc8323a8236cb05dad8684