### PR TITLE
fix: align test labels with predictions

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -660,6 +660,10 @@ class Solver(object):
         test_energy = np.array(attens_energy)
         test_labels = np.array(test_labels)
 
+        # Align label length with per-time-step energy if necessary
+        if test_labels.size * self.win_size == test_energy.size:
+            test_labels = np.repeat(test_labels, self.win_size)
+
         pred = (test_energy > thresh).astype(int)
 
         gt = test_labels.astype(int)


### PR DESCRIPTION
## Summary
- repeat test labels when necessary so they match per-step predictions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6dff424ec83238897ddadda78f43c