### PR TITLE
Handle single-class ROC AUC in test evaluation

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -701,12 +701,22 @@ class Solver(object):
         from sklearn.metrics import precision_recall_fscore_support
         from sklearn.metrics import accuracy_score, roc_auc_score
         accuracy = accuracy_score(gt, pred)
-        precision, recall, f_score, support = precision_recall_fscore_support(gt, pred,
-                                                                              average='binary')
-        auc = roc_auc_score(gt, test_energy)
+        precision, recall, f_score, support = precision_recall_fscore_support(
+            gt, pred, average='binary', zero_division=0
+        )
+
+        if len(np.unique(gt)) < 2:
+            warnings.warn(
+                "Only one class present in y_true. ROC AUC score is undefined."
+            )
+            auc = float("nan")
+        else:
+            auc = roc_auc_score(gt, test_energy)
+
         print(
             "Accuracy : {:0.4f}, Precision : {:0.4f}, Recall : {:0.4f}, F-score : {:0.4f}, AUC : {:0.4f} ".format(
-                accuracy, precision,
-                recall, f_score, auc))
+                accuracy, precision, recall, f_score, auc
+            )
+        )
 
         return accuracy, precision, recall, f_score, auc


### PR DESCRIPTION
## Summary
- prevent crash when only one class in ground truth during testing
- add zero_division handling for precision/recall calculations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6e24307dc8323aa9c3b46ae8d2d7e