### PR TITLE
Fix SKAB label detection

### DIFF
--- a/data_factory/data_loader.py
+++ b/data_factory/data_loader.py
@@ -245,8 +245,9 @@ def _skab_autodetect_cols(df: pd.DataFrame):
 
     label_col = None
     for c in df.columns:
-        uniq = pd.unique(df[c].dropna())
-        if len(uniq) <= 3 and set(pd.Series(uniq).dropna().astype(str)).issubset({"0", "1"}):
+        uniq = pd.unique(df[c])
+        uniq_num = pd.to_numeric(pd.Series(uniq), errors="coerce").dropna().unique()
+        if set(uniq_num).issubset({0, 1}):
             label_col = c
             break
 


### PR DESCRIPTION
## Summary
- refine SKAB label column detection by using `pd.to_numeric` for robust boolean checking

## Testing
- `pytest` *(skipped: 12 tests)*
- `python - <<'PY'
import types, sys
# stub torch
class DummyDataset: pass
class DummyDataLoader: pass
torch = types.SimpleNamespace()
utils = types.SimpleNamespace(data=types.SimpleNamespace(Dataset=DummyDataset, DataLoader=DummyDataLoader))
torch.utils = utils
sys.modules['torch'] = torch
sys.modules['torch.utils'] = utils
sys.modules['torch.utils.data'] = utils.data
# stub PIL.Image
PIL = types.ModuleType('PIL')
PIL.Image = types.SimpleNamespace(open=lambda *args, **kwargs: None)
sys.modules['PIL'] = PIL
sys.modules['PIL.Image'] = PIL.Image
from data_factory.data_loader import build_skab_dataset
build_skab_dataset('data', window_size=5, stride=1)
PY` *(missing dependency: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ed9110808323be90aecb0986cdc6