### PR TITLE
fix: ignore timestamp column when detecting SKAB labels

### DIFF
--- a/data_factory/data_loader.py
+++ b/data_factory/data_loader.py
@@ -245,6 +245,8 @@ def _skab_autodetect_cols(df: pd.DataFrame):
 
     label_col = None
     for c in df.columns:
+        if c == ts_col:
+            continue
         uniq = pd.unique(df[c])
         uniq_num = pd.to_numeric(pd.Series(uniq), errors="coerce").dropna().unique()
         if set(uniq_num).issubset({0, 1}):


### PR DESCRIPTION
## Summary
- avoid misidentifying timestamp column as label in SKAB dataset loader

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6ef14553083238d0bf3fa188e019a