### PR TITLE
Fix reduction of multi-dimensional labels in metric computation

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -313,6 +313,11 @@ class Solver(object):
         print(f"[compute_metrics] threshold: {thresh}")
         pred = (attens_energy > thresh).astype(int)
         gt = test_labels.astype(int)
+        # ``test_labels`` can have shape ``(n, win_size)`` with per-time-step
+        # annotations.  Reduce to a single label per window so that it matches
+        # the 1-D ``pred`` array generated above.
+        if gt.ndim > 1:
+            gt = (gt.max(axis=1) > 0).astype(int)
         print(
             f"[compute_metrics] pred positives: {np.sum(pred)}, "
             f"gt positives: {np.sum(gt)}"


### PR DESCRIPTION
## Summary
- handle multi-dimensional ground truth labels in `compute_metrics` to avoid ambiguous truth value errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a71b1ad5d88323b5d4eae769a92299